### PR TITLE
lestarch: adding fault out port for command sequencer

### DIFF
--- a/Svc/CmdSequencer/CmdSequencerComponentAi.xml
+++ b/Svc/CmdSequencer/CmdSequencerComponentAi.xml
@@ -21,6 +21,8 @@ acknowledged.
     <import_port_type>Svc/Sched/SchedPortAi.xml</import_port_type>
     <import_port_type>Svc/Seq/CmdSeqInPortAi.xml</import_port_type>
     <import_port_type>Fw/Log/LogPortAi.xml</import_port_type>
+    <!-- Must be defined by the project -->
+    <import_port_type>Svc/Fault/FaultPortAi.xml</import_port_type>
     <import_dictionary>Svc/CmdSequencer/Commands.xml</import_dictionary>
     <import_dictionary>Svc/CmdSequencer/Telemetry.xml</import_dictionary>
     <import_dictionary>Svc/CmdSequencer/Events.xml</import_dictionary>
@@ -70,6 +72,9 @@ acknowledged.
         </port>
 
         <port name="seqDone" data_type="Fw::CmdResponse"  kind="output"    max_number="1">
+        </port>
+
+        <port name="fault" data_type="Svc::Fault"  kind="output"    max_number="1">
         </port>
     </ports>
 

--- a/Svc/CmdSequencer/CmdSequencerImpl.cpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.cpp
@@ -40,14 +40,17 @@ namespace Svc {
         m_opCode(0),
         m_cmdSeq(0),
         m_join_waiting(false),
-        m_ignoreCmdFails(false)
+        m_ignoreCmdFails(false),
+        m_faultId(static_cast<Project::FaultId::t>(0))
     {
 
     }
 
     void CmdSequencerComponentImpl::init(const NATIVE_INT_TYPE queueDepth,
-            const NATIVE_INT_TYPE instance) {
+            const NATIVE_INT_TYPE instance,
+            const Project::FaultId faultId) {
         CmdSequencerComponentBase::init(queueDepth, instance);
+        m_faultId = faultId;
     }
 
     void CmdSequencerComponentImpl::setTimeout(const NATIVE_UINT_TYPE timeout) {
@@ -300,6 +303,7 @@ namespace Svc {
             if (response != Fw::COMMAND_OK) {
                 this->commandError(this->m_executedCount, opcode, response);
                 if (not this->m_ignoreCmdFails) {
+                    this->fault_out(0, m_faultId, opcode);
                     this->performCmd_Cancel();
                 } else {
                     this->log_WARNING_LO_CS_CommandFailIgnored(this->m_executedCount, opcode);

--- a/Svc/CmdSequencer/CmdSequencerImpl.hpp
+++ b/Svc/CmdSequencer/CmdSequencerImpl.hpp
@@ -542,7 +542,8 @@ namespace Svc {
       //! Initialize a CmdSequencer
       void init(
           const NATIVE_INT_TYPE queueDepth, //!< The queue depth
-          const NATIVE_INT_TYPE instance //!< The instance number
+          const NATIVE_INT_TYPE instance, //!< The instance number
+          const Project::FaultId faultId //!< Fault ID to emit
       );
 
       //! (Optional) Set a timeout. 
@@ -769,6 +770,9 @@ namespace Svc {
       // Private member variables
       // ----------------------------------------------------------------------
 
+      //! Fault id to emit
+      Project::FaultId m_faultId;
+
       //! The F Prime sequence
       FPrimeSequence m_FPrimeSequence;
 
@@ -819,7 +823,6 @@ namespace Svc {
 
       //! error handling modes
       bool m_ignoreCmdFails; //!< ignore command failures
-
   };
 
 };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description
Add fault port to command sequencer.